### PR TITLE
大佬，发现您的项目引入了io.netty:netty-codec@4.1.44.Final组件，存在安全漏洞，提一个PR，建议升级修复

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.wyk</groupId>
@@ -11,7 +9,7 @@
     <properties>
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
-        <netty.all.version>4.1.44.Final</netty.all.version>
+        <netty.all.version>4.1.68.Final</netty.all.version>
     </properties>
     <dependencies>
         <!-- https://mvnrepository.com/artifact/com.google.guava/guava -->


### PR DESCRIPTION
本次提交修复的漏洞信息:
```
漏洞标题：netty 安全漏洞
缺陷组件：io.netty:netty-codec@4.1.44.Final
漏洞编号：CVE-2021-37136
漏洞描述：Netty是Netty社区的一款非阻塞I/O客户端-服务器框架，它主要用于开发Java网络应用程序，如协议服务器和客户端等。
netty存在安全漏洞，该漏洞源于Bzip2 decompression decoder功能不允许对解压输出数据设置大小限制（这会影响解压期间使用的分配大小）。攻击者可利用该漏洞引发DoS攻击。
影响范围：(∞, 4.1.68.Final)
最小修复版本：4.1.68.Final
缺陷组件引入路径：com.wyk:shell@1.0-SNAPSHOT->io.netty:netty-codec@4.1.44.Final
```
另外我运行这个项目时，IDE的安全插件提示还有5个漏洞，我不确定升级是否会有兼容性问题。您有空的话可以查看报告修复下哈。感谢感谢。

相关漏洞详细报告：https://mofeisec.com/jr?p=p4e861